### PR TITLE
CI: Drop Ubuntu16.04 test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: ["ubuntu:18.04", "ubuntu:16.04"]
+        os: ["ubuntu:18.04"]
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 16.04 reaches end of life in April 2021, and its default python3
(python3.5) has been end of life since September 2020. Therefore it has
been decided to drop official support for the Ubuntu16.04+python3.5
combination. Ubuntu16.04 with custom installed python3.6 still works,
but it will not be tested in the CI because compatibility with python3.6
is covered by the Ubuntu18.04 test.

This commit removes the Ubuntu16.04 test job from the CI.