### PR TITLE
Replace pptk visualizer with open3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are two main categories of samples: **camera** and **applications**. The s
     - **visualization**
       - [**read_zdf_vis_3d**][read_zdf_vis_3d-url] - Read point cloud data from a ZDF file and visualize it.
         - **Dependencies:**
-          - [pptk](https://github.com/heremaps/pptk) version 0.1.0 or newer
+          - [Open3D](http://www.open3d.org/) version 0.12.0 or newer
           - [numpy](https://numpy.org/) version 1.19.2 or newer
           - [matplotlib](https://matplotlib.org/) version 3.3.2 or newer
     - **file_formats**
@@ -71,7 +71,7 @@ There are two main categories of samples: **camera** and **applications**. The s
     - [**downsample**][downsample-url]  - Downsample point cloud from a ZDF file.
       - **Dependencies:**
         - [numpy](https://numpy.org/) version 1.19.2 or newer
-        - [pptk](https://github.com/heremaps/pptk) version 0.1.0 or newer
+        - [Open3D](http://www.open3d.org/) version 0.12.0 or newer
     - [**create_depth_map**][create_depth_map-url] - Read point cloud data from a ZDF file, convert it to OpenCV format, then extract and visualize depth map.
       - **Dependencies:**
         - [numpy](https://numpy.org/) version 1.19.2 or newer
@@ -80,7 +80,7 @@ There are two main categories of samples: **camera** and **applications**. The s
       - **Dependencies:**
         - [numpy](https://numpy.org/) version 1.19.2 or newer
         - [matplotlib](https://matplotlib.org/) version 3.3.2 or newer
-        - [pptk](https://github.com/heremaps/pptk) version 0.1.0 or newer
+        - [Open3D](http://www.open3d.org/) version 0.12.0 or newer
     - [**gamma_correction**][gamma_correction-url] - Capture 2D image with gamma correction.
       - **Dependencies:**
         - [numpy](https://numpy.org/) version 1.19.2 or newer

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ matplotlib
 vtk
 vtk_visualizer
 opencv-python
-pptk
+open3d
 pyyaml
 scipy

--- a/source/applications/basic/visualization/read_zdf_vis_3d.py
+++ b/source/applications/basic/visualization/read_zdf_vis_3d.py
@@ -4,12 +4,11 @@ This example shows how to read point cloud data from a ZDF file and visualize it
 The ZDF file for this sample can be found under the main instructions for Zivid samples.
 """
 
-import math
 from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
-import pptk
 import zivid
+import open3d as o3d
 
 from sample_utils.paths import get_sample_data_path
 
@@ -50,36 +49,8 @@ def _display_depthmap(xyz):
     plt.show(block=False)
 
 
-def _get_mid_point(xyz):
-    """Calculate mid point from average of the 100 centermost points.
-
-    Args:
-        xyz: X, Y and Z images (point cloud co-ordinates)
-
-    Returns:
-        mid_point: Calculated mid point
-
-    """
-    xyz_center_cube = xyz[
-        int(xyz.shape[0] / 2 - 5) : int(xyz.shape[0] / 2 + 5),
-        int(xyz.shape[1] / 2 - 5) : int(xyz.shape[1] / 2 + 5),
-        :,
-    ]
-    return (
-        np.nanmedian(xyz_center_cube[:, :, 0]),
-        np.nanmedian(xyz_center_cube[:, :, 1]),
-        np.nanmedian(xyz_center_cube[:, :, 2]),
-    )
-
-
-def _display_pointcloud(rgb, xyz):
-    """Display point cloud.
-
-    Display the provided point cloud `xyz`, and color it with `rgb`.
-
-    We take the centermost co-ordinate as 'lookat' point. We assume that
-    camera location is at azimuth -pi/2 and elevation -pi/2 relative to
-    the 'lookat' point.
+def _display_pointcloud(xyz, rgb):
+    """Display point cloud provided from 'xyz' with colors from 'rgb'.
 
     Args:
         rgb: RGB image
@@ -88,13 +59,24 @@ def _display_pointcloud(rgb, xyz):
     Returns None
 
     """
-    mid_point = _get_mid_point(xyz)
-    point_cloud_to_view = xyz
-    point_cloud_to_view[np.isnan(xyz[:, :, 2])] = 0
-    viewer = pptk.viewer(point_cloud_to_view)
-    viewer.attributes(rgb.reshape(-1, 3) / 255.0)
-    viewer.set(lookat=mid_point)
-    viewer.set(phi=-math.pi / 2, theta=-math.pi / 2, r=mid_point[2])
+    xyz = np.nan_to_num(xyz).reshape(-1, 3)
+    rgb = rgb.reshape(-1, 3)
+
+    point_cloud_open3d = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(xyz))
+    point_cloud_open3d.colors = o3d.utility.Vector3dVector(rgb / 255)
+
+    visualizer = o3d.visualization.Visualizer()  # pylint: disable=no-member
+    visualizer.create_window()
+    visualizer.add_geometry(point_cloud_open3d)
+
+    visualizer.get_render_option().background_color = (0, 0, 0)
+    visualizer.get_render_option().point_size = 1
+    visualizer.get_render_option().show_coordinate_frame = True
+    visualizer.get_view_control().set_front([0, 0, -1])
+    visualizer.get_view_control().set_up([0, -1, 0])
+
+    visualizer.run()
+    visualizer.destroy_window()
 
 
 def _main():
@@ -114,7 +96,7 @@ def _main():
 
     _display_depthmap(xyz)
 
-    _display_pointcloud(rgba[:, :, 0:3], xyz)
+    _display_pointcloud(xyz, rgba[:, :, 0:3])
 
     input("Press Enter to close...")
 


### PR DESCRIPTION
Replacing PPTK with Open3D visualizer, since PPTK does not support Python 3.8. 
Open3D supports all python versions from 3.5 and is updated on a regular basis. 

I'm planning on updating all our visualization samples with the same function. but before I do that I want to make sure that the _display_pointcloud() function is good enough. 