### PR TITLE
Expand the Linux-Setup CI step to also cover Ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: ["ubuntu:18.04"]
+        os: ["ubuntu:18.04", "ubuntu:20.04"]
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
Default Python3:
- Ubuntu 18.04: 3.6
- Ubuntu 20.04: 3.8