### PR TITLE
Replace np.bool with bool in mask_point_cloud.py

### DIFF
--- a/source/applications/advanced/mask_point_cloud.py
+++ b/source/applications/advanced/mask_point_cloud.py
@@ -94,7 +94,7 @@ def _main():
 
     pixels_to_display = 300
     print(f"Generating binary mask of central {pixels_to_display} x {pixels_to_display} pixels")
-    mask = np.zeros((rgba.shape[0], rgba.shape[1]), np.bool)
+    mask = np.zeros((rgba.shape[0], rgba.shape[1]), bool)
     height = frame.point_cloud().height
     width = frame.point_cloud().width
     h_min = int((height - pixels_to_display) / 2)


### PR DESCRIPTION
Fixing the warning that "np.bool" is a deprecated alias for the builtin "bool"

Tested on both Windows and Ubuntu (20.04)