### PR TITLE
Link to zivid-python in README.md for supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ from the camera can be used.
 
 Note:
 
-The recommended Python version for these samples is 3.7 - 3.9.
+Supported Python versions are listed in the [zivid-python](https://github.com/zivid/zivid-python) repository.
 
 -----
 


### PR DESCRIPTION
Python 3.7 support will soon be dropped from zivid-python, so the README in this repo must be updated. It's easier just to link to the zivid-python repo for supported versions, assuming these samples are supported on all versions supported by zivid-python.